### PR TITLE
Add registration/callsign toggle for notifications and history

### DIFF
--- a/background.js
+++ b/background.js
@@ -149,7 +149,7 @@ async function pollAircraft() {
 
     const { notificationsEnabled = true, notificationTimeout = 10, notifShow = {} } =
       await chrome.storage.local.get(['notificationsEnabled', 'notificationTimeout', 'notifShow']);
-    const show = Object.assign({ type: true, alt: true, speed: true, route: true, dir: true }, notifShow);
+    const show = Object.assign({ reg: false, type: true, alt: true, speed: true, route: true, dir: true }, notifShow);
 
     if (notificationsEnabled) {
       const notifId = `notif_${key}_${now}`;
@@ -173,7 +173,7 @@ async function pollAircraft() {
     await playAlertSound(alertSound, alertVolume);
 
     // Sla op in geschiedenis
-    const callsign = ac.flight?.trim() || ac.r || ac.hex;
+    const callsign = show.reg ? (ac.r || ac.flight?.trim() || ac.hex) : (ac.flight?.trim() || ac.r || ac.hex);
     const parts = [];
     if (ac.alt_baro && ac.alt_baro !== 'ground') parts.push(`${Math.round(ac.alt_baro * 0.3048)}m`);
     if (ac.gs) parts.push(`${Math.round(ac.gs * 1.852)} km/h`);
@@ -240,8 +240,8 @@ function matchesAlert(ac, alert) {
 }
 
 function buildTitle(ac, alert, show = {}) {
-  const id = ac.flight?.trim() || ac.r || ac.hex;
-  const type = (show.type !== false) && ac.t ? ` (${ac.t})` : '';
+  const id    = show.reg ? (ac.r || ac.flight?.trim() || ac.hex) : (ac.flight?.trim() || ac.r || ac.hex);
+  const type  = (show.type !== false) && ac.t ? ` (${ac.t})` : '';
   const emoji = alert.type === 'dbflag' && alert.value.toLowerCase() === 'military' ? '🪖' : '✈️';
   return `${emoji} ${id}${type} spotted!`;
 }

--- a/popup/settings.js
+++ b/popup/settings.js
@@ -92,6 +92,10 @@ function initSettingsTab() {
           </div>
           <div class="notif-toggle-list">
             <div class="notif-toggle-row">
+              <span class="notif-toggle-label">Show registration instead of callsign</span>
+              <button class="alert-toggle" id="notifToggleReg"></button>
+            </div>
+            <div class="notif-toggle-row">
               <span class="notif-toggle-label">Aircraft type in title</span>
               <button class="alert-toggle on" id="notifToggleType"></button>
             </div>
@@ -392,11 +396,13 @@ async function initSettings() {
   });
 
   // Notificatie content builder
-  const defaultShow = { type: true, alt: true, speed: true, route: true, dir: true };
+  const defaultShow = { reg: false, type: true, alt: true, speed: true, route: true, dir: true };
   const show = Object.assign({}, defaultShow, notifShow);
 
   function updateNotifPreview() {
-    const title = show.type ? '✈️ PH-BXA (B744) spotted!' : '✈️ PH-BXA spotted!';
+    const id    = show.reg ? 'PH-BXA' : 'KL1234';
+    const type  = show.type ? ` (B744)` : '';
+    const title = `✈️ ${id}${type} spotted!`;
     const parts = [];
     if (show.alt)   parts.push('8500m');
     if (show.speed) parts.push('850 km/h');
@@ -418,6 +424,7 @@ async function initSettings() {
     });
   }
 
+  makeNotifToggle('notifToggleReg',   'reg');
   makeNotifToggle('notifToggleType',  'type');
   makeNotifToggle('notifToggleAlt',   'alt');
   makeNotifToggle('notifToggleSpeed', 'speed');
@@ -553,7 +560,7 @@ async function initSettings() {
     chrome.notifications.create(`test_${Date.now()}`, {
       type:    'basic',
       iconUrl: '../icons/icon128.png',
-      title:   s.type ? '✈️ PH-TEST (B744) spotted!' : '✈️ PH-TEST spotted!',
+      title:   `✈️ ${s.reg ? 'PH-TEST' : 'PHTEST1'}${s.type ? ' (B744)' : ''} spotted!`,
       message: parts.join(' · ') || '—',
       buttons: [{ title: '🗺️ View on map' }]
     });


### PR DESCRIPTION
Users can now choose whether notifications and history entries show the aircraft's registration number (e.g. PH-BXA) or callsign (e.g. KL1234). Useful when cross-referencing with tools like Skycards. The toggle is off by default, keeping the existing behaviour.