### PR TITLE
Replace mute system with caught aircraft

### DIFF
--- a/background.js
+++ b/background.js
@@ -125,12 +125,12 @@ async function pollAircraft() {
   const now = Date.now();
 
   // Load which aircraft were in range during the previous poll
-  const { inRange = {}, mutedAircraft = [] } = await chrome.storage.local.get(['inRange', 'mutedAircraft']);
+  const { inRange = {}, caughtAircraft = [] } = await chrome.storage.local.get(['inRange', 'caughtAircraft']);
   const newInRange = {};
 
   for (const ac of aircraft) {
-    // Skip gemutede kisten
-    if (ac.hex && mutedAircraft.includes(ac.hex)) continue;
+    // Skip gevangen vliegtuigen
+    if (ac.hex && caughtAircraft.includes(ac.hex)) continue;
 
     // Check which alert (if any) matches this aircraft
     const matchingAlert = config.alerts.find(alert => alert.active && matchesAlert(ac, alert));
@@ -158,7 +158,7 @@ async function pollAircraft() {
         iconUrl: 'icons/icon128.png',
         title:   buildTitle(ac, matchingAlert, show),
         message: buildMessage(ac, config, show),
-        buttons: [{ title: '🗺️ View on map' }]
+        buttons: [{ title: '🗺️ View on map' }, { title: '🎯 Mark as caught' }]
       });
     }
 
@@ -194,10 +194,23 @@ async function pollAircraft() {
   await chrome.storage.local.set({ inRange: newInRange, lastPoll: now, lastCount: aircraft.length, cachedAircraft: data.ac || [] });
 }
 
-// Click on notification button → open the map
-chrome.notifications.onButtonClicked.addListener((notifId, btnIdx) => {
+// Click on notification button
+chrome.notifications.onButtonClicked.addListener(async (notifId, btnIdx) => {
   if (btnIdx === 0) {
     chrome.tabs.create({ url: 'https://globe.airplanes.live' });
+  }
+  if (btnIdx === 1) {
+    // Extract hex from notifId format: notif_<hex>_<timestamp>
+    const parts = notifId.split('_');
+    if (parts.length >= 3) {
+      const hex = parts[1];
+      const { caughtAircraft = [] } = await chrome.storage.local.get('caughtAircraft');
+      if (!caughtAircraft.includes(hex)) {
+        caughtAircraft.push(hex);
+        await chrome.storage.local.set({ caughtAircraft });
+      }
+    }
+    chrome.notifications.clear(notifId);
   }
 });
 

--- a/popup/history.js
+++ b/popup/history.js
@@ -11,6 +11,17 @@ function initHistoryTab() {
     <div class="history-list" id="historyList">
       <div class="empty-state">No notifications yet.</div>
     </div>
+
+    <div class="caught-dropdown" id="caughtDropdown" style="margin-top:14px;border:1px solid #1a2a4a;border-radius:8px;overflow:hidden">
+      <button id="btnToggleCaught" style="width:100%;display:flex;justify-content:space-between;align-items:center;padding:9px 12px;background:#0d1530;border:none;cursor:pointer;color:#c8d4f0;font-family:'Space Mono',monospace;font-size:11px">
+        <span>🎯 Caught aircraft</span>
+        <span id="caughtChevron" style="font-size:10px;transition:transform 0.2s">▼</span>
+      </button>
+      <div id="caughtPanel" style="display:none;padding:10px 12px;background:#080f25">
+        <div id="caughtList"></div>
+        <button class="btn-option" id="btnClearCaught" style="width:100%;padding:7px;margin-top:8px">Release all</button>
+      </div>
+    </div>
   `;
   setupHistoryEvents();
 }
@@ -21,6 +32,46 @@ function setupHistoryEvents() {
   document.getElementById('btnClearHistory').addEventListener('click', async () => {
     await chrome.storage.local.set({ notifHistory: [] });
     loadHistory();
+  });
+
+  document.getElementById('btnToggleCaught').addEventListener('click', () => {
+    const panel   = document.getElementById('caughtPanel');
+    const chevron = document.getElementById('caughtChevron');
+    const isOpen  = panel.style.display !== 'none';
+    panel.style.display   = isOpen ? 'none' : 'block';
+    chevron.style.transform = isOpen ? '' : 'rotate(180deg)';
+    if (!isOpen) renderCaughtList();
+  });
+
+  document.getElementById('btnClearCaught').addEventListener('click', async () => {
+    await chrome.storage.local.set({ caughtAircraft: [] });
+    renderCaughtList();
+  });
+}
+
+async function renderCaughtList() {
+  const { caughtAircraft = [] } = await chrome.storage.local.get('caughtAircraft');
+  const list = document.getElementById('caughtList');
+
+  if (caughtAircraft.length === 0) {
+    list.innerHTML = '<div style="font-family:Space Mono,monospace;font-size:10px;color:#4b5680;padding:4px 0">No caught aircraft.</div>';
+    return;
+  }
+
+  list.innerHTML = '';
+  caughtAircraft.forEach(hex => {
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;justify-content:space-between;align-items:center;padding:5px 0;border-bottom:1px solid #1a2040';
+    row.innerHTML = `
+      <span style="font-family:'Space Mono',monospace;font-size:11px;color:#c8d4f0">${hex}</span>
+      <button style="background:none;border:1px solid #2a3060;color:#4b5680;font-size:10px;padding:2px 8px;border-radius:5px;cursor:pointer" data-hex="${hex}">↩️ Release</button>
+    `;
+    row.querySelector('button').addEventListener('click', async () => {
+      const { caughtAircraft: current = [] } = await chrome.storage.local.get('caughtAircraft');
+      await chrome.storage.local.set({ caughtAircraft: current.filter(h => h !== hex) });
+      renderCaughtList();
+    });
+    list.appendChild(row);
   });
 }
 

--- a/popup/live.js
+++ b/popup/live.js
@@ -45,7 +45,7 @@ function initLiveTab() {
       </div>
       <div class="detail-grid" id="detailGrid"></div>
       <button class="detail-map-btn" id="detailMapBtn">🗺️ Open on map</button>
-      <button class="detail-mute-btn" id="detailMuteBtn">🔇 Mute this aircraft</button>
+      <button class="detail-catch-btn" id="detailCatchBtn">🎯 Catch this aircraft</button>
     </div>
   `;
   setupLiveEvents();
@@ -108,12 +108,12 @@ function setupLiveEvents() {
     currentDetailHex = null;
   });
 
-  document.getElementById('detailMuteBtn').addEventListener('click', async () => {
+  document.getElementById('detailCatchBtn').addEventListener('click', async () => {
     if (!currentDetailHex) return;
-    const { mutedAircraft = [] } = await chrome.storage.local.get('mutedAircraft');
-    if (!mutedAircraft.includes(currentDetailHex)) {
-      mutedAircraft.push(currentDetailHex);
-      await chrome.storage.local.set({ mutedAircraft });
+    const { caughtAircraft = [] } = await chrome.storage.local.get('caughtAircraft');
+    if (!caughtAircraft.includes(currentDetailHex)) {
+      caughtAircraft.push(currentDetailHex);
+      await chrome.storage.local.set({ caughtAircraft });
     }
     document.getElementById('detailPanel').classList.remove('visible');
     currentDetailHex = null;
@@ -145,8 +145,8 @@ function getAltitudeM(ac) {
 // ─── RENDER LIJST ──────────────────────────────────────────────────────────
 
 async function renderAircraftList() {
-  const { lat, lon, hideGround = true, alerts = [], mutedAircraft = [] } =
-    await chrome.storage.local.get(['lat', 'lon', 'hideGround', 'alerts', 'mutedAircraft']);
+  const { lat, lon, hideGround = true, alerts = [], caughtAircraft = [] } =
+    await chrome.storage.local.get(['lat', 'lon', 'hideGround', 'alerts', 'caughtAircraft']);
 
   const list    = document.getElementById('acList');
   const countEl = document.getElementById('liveCount');
@@ -154,12 +154,12 @@ async function renderAircraftList() {
 
   const DB_FLAGS = { military: 1, interesting: 2, pia: 4, ladd: 8 };
 
-  function isMuted(ac) {
-    return (mutedAircraft || []).includes(ac.hex);
+  function isCaught(ac) {
+    return (caughtAircraft || []).includes(ac.hex);
   }
 
   function isMatch(ac) {
-    if (isMuted(ac)) return false;
+    if (isCaught(ac)) return false;
     return alerts.some(alert => {
       if (!alert.active) return false;
       const v = alert.value.toUpperCase();
@@ -216,7 +216,7 @@ async function renderAircraftList() {
     const item     = document.createElement('div');
     item.className = `ac-item${match ? ' match' : ''}`;
 
-    const muted    = isMuted(ac);
+    const caught    = isCaught(ac);
     const flight   = ac.flight?.trim() || ac.r || ac.hex || '???';
     const type     = ac.t || '';
     const altitude = ac.alt_baro && ac.alt_baro !== 'ground'
@@ -229,7 +229,7 @@ async function renderAircraftList() {
 
     item.innerHTML = `
       <div style="min-width:0">
-        <div class="ac-flight">${flight}${match ? '<span class="match-badge">MATCH</span>' : ''}${muted ? '<span class="mute-badge">MUTED</span>' : ''}</div>
+        <div class="ac-flight">${flight}${match ? '<span class="match-badge">MATCH</span>' : ''}${caught ? '<span class="caught-badge">CAUGHT</span>' : ''}</div>
         <div class="ac-detail">${route}</div>
         ${dist ? `<div class="ac-distance">${dist}</div>` : ''}
       </div>
@@ -340,20 +340,20 @@ function openDetailPanel(ac) {
     chrome.tabs.create({ url: `https://globe.airplanes.live/?icao=${ac.hex}` });
   };
 
-  // Mute knop updaten
-  chrome.storage.local.get('mutedAircraft').then(({ mutedAircraft = [] }) => {
-    const btn = document.getElementById('detailMuteBtn');
-    const muted = mutedAircraft.includes(ac.hex);
-    btn.textContent = muted ? '🔊 Unmute this aircraft' : '🔇 Mute this aircraft';
+  // Catch knop updaten
+  chrome.storage.local.get('caughtAircraft').then(({ caughtAircraft = [] }) => {
+    const btn = document.getElementById('detailCatchBtn');
+    const caught = caughtAircraft.includes(ac.hex);
+    btn.textContent = caught ? '↩️ Release this aircraft' : '🎯 Catch this aircraft';
     btn.onclick = async () => {
-      const { mutedAircraft: current = [] } = await chrome.storage.local.get('mutedAircraft');
+      const { caughtAircraft: current = [] } = await chrome.storage.local.get('caughtAircraft');
       const idx = current.indexOf(ac.hex);
       if (idx === -1) {
         current.push(ac.hex);
       } else {
         current.splice(idx, 1);
       }
-      await chrome.storage.local.set({ mutedAircraft: current });
+      await chrome.storage.local.set({ caughtAircraft: current });
       document.getElementById('detailPanel').classList.remove('visible');
       currentDetailHex = null;
       renderAircraftList();

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -551,16 +551,16 @@ input::placeholder { color: #3a4560; }
   margin-left: 6px;
 }
 
-.mute-badge {
+.caught-badge {
   font-size: 9px;
-  background: #2a1a1a;
-  color: #6b7ca8;
+  background: #0a2a1a;
+  color: #4ade80;
   padding: 2px 6px;
   border-radius: 10px;
   margin-left: 6px;
 }
 
-.detail-mute-btn {
+.detail-catch-btn {
   width: 100%;
   background: #1a1a2a;
   color: #6b7ca8;
@@ -574,7 +574,7 @@ input::placeholder { color: #3a4560; }
   cursor: pointer;
   transition: all 0.15s;
 }
-.detail-mute-btn:hover { color: #ef4444; border-color: #4a1a1a; background: #1a0a0a; }
+.detail-catch-btn:hover { color: #ef4444; border-color: #4a1a1a; background: #1a0a0a; }
 
 .live-controls {
   margin-bottom: 10px;

--- a/popup/settings.js
+++ b/popup/settings.js
@@ -117,14 +117,6 @@ function initSettingsTab() {
       </div>
     </div>
 
-    <!-- 🔇 Muted aircraft -->
-    <div class="settings-card">
-      <div class="settings-card-title">🔇 Muted aircraft</div>
-      <p style="font-family:'Space Mono',monospace;font-size:9px;color:#4b5680;margin:0 0 10px">Aircraft you have muted via the Live tab. They will not trigger notifications.</p>
-      <div id="mutedList" style="margin-bottom:8px"></div>
-      <button class="btn-option" id="btnClearMuted" style="width:100%;padding:8px">Clear all muted aircraft</button>
-    </div>
-
     <!-- 💾 Backup & Test -->
     <div class="settings-card">
       <div class="settings-card-title">💾 Backup &amp; Test</div>
@@ -368,41 +360,6 @@ async function initSettings() {
   makeNotifToggle('notifToggleDir',   'dir');
   updateNotifPreview();
 
-  // ── Muted aircraft ───────────────────────────────────────────────────────
-
-  async function renderMutedList() {
-    const { mutedAircraft = [] } = await chrome.storage.local.get('mutedAircraft');
-    const list = document.getElementById('mutedList');
-    if (mutedAircraft.length === 0) {
-      list.innerHTML = '<div style="font-family:Space Mono,monospace;font-size:10px;color:#2a3060">No muted aircraft.</div>';
-      return;
-    }
-    list.innerHTML = '';
-    mutedAircraft.forEach(hex => {
-      const row = document.createElement('div');
-      row.style.cssText = 'display:flex;justify-content:space-between;align-items:center;padding:6px 0;border-bottom:1px solid #1a2040';
-      row.innerHTML = `
-        <span style="font-family:'Space Mono',monospace;font-size:11px;color:#c8d4f0">${hex}</span>
-        <button style="background:none;border:1px solid #2a3060;color:#4b5680;font-size:10px;padding:2px 8px;border-radius:5px;cursor:pointer" data-hex="${hex}">Unmute</button>
-      `;
-      row.querySelector('button').addEventListener('click', async () => {
-        const { mutedAircraft: current = [] } = await chrome.storage.local.get('mutedAircraft');
-        await chrome.storage.local.set({ mutedAircraft: current.filter(h => h !== hex) });
-        renderMutedList();
-        showSaved('Unmuted');
-      });
-      list.appendChild(row);
-    });
-  }
-
-  renderMutedList();
-
-  document.getElementById('btnClearMuted').addEventListener('click', async () => {
-    await chrome.storage.local.set({ mutedAircraft: [] });
-    renderMutedList();
-    showSaved('Muted list cleared');
-  });
-
   // ── Startup tab ──────────────────────────────────────────────────────────
 
   const { startupTab = 'last' } = await chrome.storage.local.get('startupTab');
@@ -427,7 +384,7 @@ async function initSettings() {
     'hideGround', 'notificationsEnabled', 'notifShow',
     'alertSound', 'alertVolume',
     'startupTab', 'lastTab',
-    'mutedAircraft'
+    'caughtAircraft'
   ];
 
   document.getElementById('btnExportAlerts').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
Replaces the mute system with a "caught aircraft" concept, inspired by the Skycards app workflow. Aircraft you've already caught in Skycards can be marked as caught in Plane Alert — suppressing future notifications so you're not alerted for aircraft you've already collected.

## Changes

**`background.js`**
- Renamed `mutedAircraft` → `caughtAircraft` in storage and polling logic
- Added `🎯 Mark as caught` as a second button on desktop notifications
- Clicking the catch button saves the aircraft to `caughtAircraft` and dismisses the notification

**`live.js`**
- `🔇 Mute this aircraft` → `🎯 Catch this aircraft`
- `🔊 Unmute this aircraft` → `↩️ Release this aircraft`
- `MUTED` badge → `CAUGHT` badge
- All storage keys, variable names and element IDs updated accordingly

**`settings.js`**
- Removed the muted aircraft card (HTML + JS)
- Updated `BACKUP_KEYS`: `mutedAircraft` → `caughtAircraft`

**`history.js`**
- Added a collapsible `🎯 Caught aircraft` dropdown at the bottom of the History tab
- Supports per-aircraft release and a "Release all" button

**`popup.css`**
- `.mute-badge` → `.caught-badge` with a green color scheme
- `.detail-mute-btn` → `.detail-catch-btn`

## Notes
- Existing `mutedAircraft` data in storage will not be migrated automatically. Users will need to re-catch their aircraft after updating.
- No changes to the polling logic or notification trigger conditions.