### PR TITLE
fix: use overflow clip on panels-wrapper to prevent dropdown overlapping donate footer

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -256,7 +256,7 @@ body {
 .tab.active { color: #60a5fa; border-bottom-color: #60a5fa; }
 
 /* ── Panels wrapper ── */
-.panels-wrapper { position: relative; flex: 1; min-height: 0; }
+.panels-wrapper { position: relative; flex: 1; min-height: 0; overflow: clip; }
 
 .disabled-overlay {
   display: none;


### PR DESCRIPTION
closes #32 